### PR TITLE
Update syntax and configs for Dependabot

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,15 @@
+pull_request_rules:
+   - name: Automatic merge for Dependabot pull requests
+     conditions:
+       - author~=^dependabot\[bot\]$
+       - status-success=Validate
+       - status-success=Format
+       - status-success=Lint
+       - status-success=Security
+       - status-success=Docs
+       - status-success=Labels
+       - base=main
+     actions:
+       merge:
+         method: squash
+         strict: true

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,22 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.49.0"
+  version     = "3.53.0"
   constraints = ">= 2.53.0, ~> 3.0, >= 3.15.0, >= 3.40.0"
   hashes = [
-    "h1:Xvsiilfz2CItH9EsDLXzpFf10ARDNmXm0Ey4s/vPluM=",
-    "h1:klBcGkbCZhDo95eRUz1c0Sj1J97RNfSceZLzbwaFVaQ=",
-    "zh:35fa4cf6669ef6d4b002bc1494ef7168c3100c1248e9b7ef4ac1112209455e4d",
-    "zh:59742ddcaa52a7279966809c792951f4b4b8e3d5b769205a0598030cd7dcfa89",
-    "zh:5b36ae146ad0dc5d228ecb52f5160673ed02cf7e5415fde8da2f99fd8037d37d",
-    "zh:61713827833a9411abe1bc46616469a6f1be2395960268e478d901700b2176fa",
-    "zh:6726690c72204b542e8fd7bb0d725874ea6c5d21ce1e76afe458fd56ff371a77",
-    "zh:a8c222830241d09faaa56e318a305b2af12c80ee675ee5af10cd33cc9ddfa1b9",
-    "zh:b41d140ee952ff796c384e9a9f0cbefb80cda5f140595c0bb04b20c4338caf14",
-    "zh:b94848e3f2acc3bc899639c546f5d8673cfe9dee1f18138508f6d835b3393de1",
-    "zh:c1866f25050c8a408daf30a36ddf87a5d744657a81b88ba2fff77b8b8b8e30c1",
-    "zh:f26a7be8b4459fed1786b2752d83bf95eef8862b6b7c4758c30b36bf2f4380f3",
-    "zh:f69e4f8c700e9449f2f444784a08c08aa5532d8c269f83740b56b7ac7a478926",
+    "h1:oRCCzfwGCDNyuhIJ8kCg0N7h4W2WESm37o2GIt0ETpQ=",
+    "zh:35a77c79170b0cf3fb7eb835f3ce0b715aeeceda0a259e96e49fed5a30cf6646",
+    "zh:519d5470a932b1ec9a0fe08876c5e0f0f84f8e506b652c051e4ab708be081e89",
+    "zh:58cfa5b454602d57c47acd15c2ad166a012574742cdbcf950787ce79b6510218",
+    "zh:5fc3c0162335a730701c0175809250233f45f1021da8fa52c73635e4c08372d8",
+    "zh:6790f9d6261eb4bd5cdd7cd9125f103befce2ba127f9ba46eef83585b86e1d11",
+    "zh:76e1776c3bf9568d520f78419ec143c081f653b8df4fb22577a8c4a35d3315f9",
+    "zh:ca8ed88d0385e45c35223ace59b1bf77d81cd2154d5416e63a3dddaf0def30e6",
+    "zh:d002562c4a89a9f1f6cd8d854fad3c66839626fc260e5dde5267f6d34dbd97a4",
+    "zh:da5e47fb769e90a2f16c90fd0ba95d62da3d76eb006823664a5c6e96188731b0",
+    "zh:dfe7f33ec252ea550e090975a5f10940c27302bebb5559957957937b069646ea",
+    "zh:fa91574605ddce726e8a4e421297009a9dabe023106e139ac46da49c8285f2fe",
   ]
 }
 
@@ -26,7 +25,6 @@ provider "registry.terraform.io/hashicorp/local" {
   constraints = ">= 1.2.0, ~> 2.0"
   hashes = [
     "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
-    "h1:KfieWtVyGWwplSoLIB5usKAUnrIkDQBkWaR5TI+4WYg=",
     "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
     "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
     "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
@@ -46,7 +44,6 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = "~> 3.0"
   hashes = [
     "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
-    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
     "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Using this module also allows integration with existing AWS resources -- VPC, Su
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.53.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | 2.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ module "refinery" {
   # or
   # Pull a specific version from Terraform Module Registry
   source  = "Vlaaaaaaad/fargate-refinery/aws"
-  version = "0.3.1"
+  version = "0.3.2"
 
   # REQUIRED: DNS (without trailing dot)
   route53_zone_name = "example.com"

--- a/versions.tf
+++ b/versions.tf
@@ -2,8 +2,18 @@ terraform {
   required_version = "~> 1"
 
   required_providers {
-    aws    = "~> 3"
-    local  = "~> 2"
-    random = "~> 3"
+    aws = {
+      version = "~> 3"
+      source  = "hashicorp/aws"
+    }
+    local = {
+      version = "~> 2"
+      source  = "hashicorp/local"
+    }
+    random = {
+      version = "~> 3"
+      source  = "hashicorp/random"
+    }
   }
 }
+


### PR DESCRIPTION
## Description

This PR updates the provider syntax to the latest version so we can use Dependabot updates.

## Notes

I'm kind of disappointed `terraform validate` did not even alert about the syntax being deprecated.
