### PR TITLE
Module bumps and GitHub Actions cleanup

### DIFF
--- a/.github/auto-label.yml
+++ b/.github/auto-label.yml
@@ -1,12 +1,14 @@
-bump:patch:
-  - '**'
-  - '.*'
-  - '.*/**'
-
 area/automation:
   - .github/*
   - .github/**/*
+  - .pre-commit-config.yaml
+  - .terraform-docs.yml
+  - .gitpod.yml
   - .mergify.yml
 
 area/terraform:
   - '**/*.tf'
+  - 'templates/**'
+  - .terraform.lock.hcl
+  - .pre-commit-config.yaml
+  - .terraform-docs.yml

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -7,6 +7,9 @@ on:
       - .github/workflows/labels.yml
     branches:
       - main
+  schedule:
+      # run every Saturday
+    - cron:  '0 0 * * SAT'
 
 jobs:
   Manage:
@@ -14,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Clone repo
+      - name: Get the code
         uses: actions/checkout@v2
 
-      - name: Manage labels
+      - name: Manage labels available on the repo
         uses: micnncim/action-label-syncer@v1
         with:
           manifest: .github/labels.yml

--- a/.github/workflows/pr-conformance.yml
+++ b/.github/workflows/pr-conformance.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Clone repo
+      - name: Get the code
         uses: actions/checkout@v2
 
-      - name: Assign content labels
+      - name: Assign labels based on the PR content
         if: github.actor != 'dependabot[bot]'
         # Labels are added manually in .github/dependabot.yml
         #  due to Dependabot secrets issues
@@ -20,9 +20,10 @@ jobs:
         uses: actions/labeler@v3
         with:
           configuration-path: .github/auto-label.yml
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true
 
-      - name: Assign size label
+      - name: Assign a size label based on the number of lines changed
         uses: pascalgn/size-label-action@v0.4.3
         if: github.actor != 'dependabot[bot]'
         # Skip the size label due to due to Dependabot secrets issues

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get the code
+        uses: actions/checkout@v2
+
+      - name: Create a release based on the PR labels
+        id: bumpr
+        uses: haya14busa/action-bumpr@v1
+        with:
+          default_bump_level: patch
+
+      - name: Create a pretty GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.bumpr.outputs.next_version }}
+          name: Release ${{ steps.bumpr.outputs.next_version }}
+          body: ${{ steps.bumpr.outputs.message }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -12,133 +12,239 @@ on:
       - '**.tf'
       - '**.tpl'
 
+env:
+  HOMEBREW_NO_INSTALL_CLEANUP: "ON"
+  HOMEBREW_CACHE: ${{ github.workspace }}/.cache/brew
+
 jobs:
   Format:
     runs-on: ubuntu-latest
+    outputs:
+      needs_fix: ${{ steps.decision.outputs.needs_fix }}
 
     steps:
-      - name: Clone repo
+      - name: Get the code
         if: github.event_name == 'push'
         uses: actions/checkout@v2
-
-      - name: Clone repo
+      - name: Get the code
         if: github.event_name != 'push'
         uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Install dependencies
-        env:
-          HOMEBREW_NO_INSTALL_CLEANUP: 1
-        run: |
-          brew install terraform
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v1
 
       - name: Check formatting
+        id: formatting_check
+        run: terraform fmt -check
+
+      - name: Set output
+        if: always()
+        id: decision
+        # Use a custom output to run auto-fixes only if the docs check failed,
+        #  and not if installing dependencies failed, for example.
         run: |
-          terraform fmt -check
+          if [[ "${{ steps.formatting_check.outcome }}" == "success" ]]; then
+            echo "::set-output name=needs_fix::false"
+          else
+            echo "::set-output name=needs_fix::true"
+          fi
 
   Validate:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Clone repo
+      - name: Get the code
+        if: github.event_name == 'push'
         uses: actions/checkout@v2
+      - name: Get the code
+        if: github.event_name != 'push'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
 
-      - name: Install dependencies
-        env:
-          HOMEBREW_NO_INSTALL_CLEANUP: 1
-        run: |
-          brew install terraform
+      - name: Setup the Terraform cache
+        uses: actions/cache@v2
+        with:
+          path: .terraform
+          key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v1
 
       - name: Terraform init
-        run: |
-          terraform init
+        run: terraform init
 
       - name: Validate
-        env:
-          # Set AWS region due to https://github.com/hashicorp/terraform/issues/21408
-          AWS_DEFAULT_REGION: us-east-1
-        run: |
-          terraform validate
+        run: terraform validate
 
   Lint:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Clone repo
+      - name: Get the code
+        if: github.event_name == 'push'
         uses: actions/checkout@v2
+      - name: Get the code
+        if: github.event_name != 'push'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
 
-      - name: Install dependencies
-        env:
-          HOMEBREW_NO_INSTALL_CLEANUP: 1
-        run: |
-          brew install terraform
+      - name: Setup the Terraform cache
+        uses: actions/cache@v2
+        with:
+          path: .terraform
+          key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v1
 
       - name: Terraform init
-        run: |
-          terraform init
+        run: terraform init
 
       - name: Run tflint with review comment on PR
         uses: reviewdog/action-tflint@master
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
-          flags: "--module"
+          flags: --module
 
   Docs:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
+    outputs:
+      needs_fix: ${{ steps.decision.outputs.needs_fix }}
 
     steps:
-      - name: Clone repo
+      - name: Get the code
         if: github.event_name == 'push'
         uses: actions/checkout@v2
-
-      - name: Clone repo
+      - name: Get the code
         if: github.event_name != 'push'
         uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
+      - name: Setup the Homebrew cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.HOMEBREW_CACHE }}
+          key: ${{ runner.os }}-brew-
+      - name: Setup the Terraform cache
+        uses: actions/cache@v2
+        with:
+          path: .terraform
+          key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v1
       - name: Install dependencies
-        env:
-          HOMEBREW_NO_INSTALL_CLEANUP: 1
-        run: |
-          brew install pre-commit gawk coreutils terraform-docs terraform
+        run: brew install pre-commit terraform-docs
 
       - name: Check Docs
-        env:
-          AWS_DEFAULT_REGION: us-east-1
+        id: docs_check
         run: pre-commit run --show-diff-on-failure --all-files terraform_docs
+
+      - name: Set output
+        if: failure()
+        id: decision
+        # Use a custom output to run auto-fixes only if the docs check failed,
+        #  and not if installing dependencies failed, for example.
+        run: |
+          if [[ "${{ steps.docs_check.outcome }}" == "success" ]]; then
+            echo "::set-output name=needs_fix::false"
+          else
+            echo "::set-output name=needs_fix::true"
+          fi
 
   Security:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Clone repo
+      - name: Get the code
+        if: github.event_name == 'push'
         uses: actions/checkout@v2
+      - name: Get the code
+        if: github.event_name != 'push'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
 
-      - name: Install dependencies
-        env:
-          HOMEBREW_NO_INSTALL_CLEANUP: 1
-        run: |
-          brew install terraform
+      - name: Setup the Terraform cache
+        uses: actions/cache@v2
+        with:
+          path: .terraform
+          key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v1
 
       - name: Terraform init
-        run: |
-          terraform init
+        run: terraform init
 
       - name: Run tfsec with review comment on PR
         if: github.event_name == 'pull_request'
         uses: reviewdog/action-tfsec@master
         with:
           github_token: ${{ secrets.github_token }}
-          reporter: "github-pr-review"
-          filter_mode: "nofilter"
+          reporter: github-pr-review
+          filter_mode: nofilter
 
       - name: Run tfsec on the commit
         if: github.event_name == 'push'
         uses: reviewdog/action-tfsec@master
         with:
           github_token: ${{ secrets.github_token }}
-          reporter: "github-check"
-          filter_mode: "nofilter"
+          reporter: github-check
+          filter_mode: nofilter
+
+  Autofix:
+    name: Autofix small issues
+    runs-on: ubuntu-latest
+    needs: [Validate, Format, Docs]
+    if: |
+      failure() &&
+      needs.Validate.result == 'success' &&
+      (needs.Docs.outputs.needs_fix == 'true' || needs.Format.outputs.needs_fix == 'true') &&
+      github.repository == 'Vlaaaaaaad/terraform-aws-fargate-refinery'
+
+    steps:
+      - name: Get the code
+        if: github.event_name == 'push'
+        uses: actions/checkout@v2
+        # See https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
+        with:
+          token: ${{ secrets.VLAAAAAAAD_PERSONAL_ACCESS_TOKEN }}
+      - name: Get the code
+        if: github.event_name != 'push'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.VLAAAAAAAD_PERSONAL_ACCESS_TOKEN }}
+      - name: Setup the Homebrew cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.HOMEBREW_CACHE }}
+          key: ${{ runner.os }}-brew-
+      - name: Setup the Terraform cache
+        uses: actions/cache@v2
+        with:
+          path: .terraform
+          key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v1
+      - name: Install dependencies
+        run: brew install pre-commit terraform-docs
+
+      - name: Fix the README
+        if: needs.Docs.outputs.needs_fix == 'true'
+        run: pre-commit run --all-files terraform_docs
+
+      - name: Fix code formatting
+        if: needs.Format.outputs.needs_fix == 'true'
+        run: pre-commit run --all-files terraform_fmt
+
+      - name: Push changes to the PR
+        if: failure()
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Autofixes for formatting & docs
+          commit_user_email: github-actions@github.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-#  Local .terraform directories
+# GitHub Actions cache
+**/.cache/*
+
+#  Local .terraform directories and caches
 **/.terraform/*
 
 # .tfstate files
@@ -9,7 +12,6 @@
 *.tfvars
 
 .DS_Store
-.DS_Store?
 **/.DS_Store
 ._*
 .Spotlight-V100

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.53.0"
   constraints = ">= 2.53.0, ~> 3.0, >= 3.15.0, >= 3.40.0"
   hashes = [
+    "h1:kcda9YVaFUzBFVtKXNZrQB801i2XkH1Y5gbdOHNpB38=",
     "h1:oRCCzfwGCDNyuhIJ8kCg0N7h4W2WESm37o2GIt0ETpQ=",
     "zh:35a77c79170b0cf3fb7eb835f3ce0b715aeeceda0a259e96e49fed5a30cf6646",
     "zh:519d5470a932b1ec9a0fe08876c5e0f0f84f8e506b652c051e4ab708be081e89",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/local" {
   constraints = ">= 1.2.0, ~> 2.0"
   hashes = [
     "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
+    "h1:KfieWtVyGWwplSoLIB5usKAUnrIkDQBkWaR5TI+4WYg=",
     "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
     "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
     "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
@@ -44,6 +46,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = "~> 3.0"
   hashes = [
     "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
+    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
     "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",

--- a/alb.tf
+++ b/alb.tf
@@ -1,7 +1,7 @@
 #tfsec:ignore:AWS005 tfsec:ignore:AWS083 tfsec:ignore:AWS004
 module "alb" {
   source  = "terraform-aws-modules/alb/aws"
-  version = "6.3.0"
+  version = "6.4.0"
 
   name = format(
     "%.32s",

--- a/dns.tf
+++ b/dns.tf
@@ -21,7 +21,7 @@ resource "aws_route53_record" "refinery" {
 
 module "certificate" {
   source  = "terraform-aws-modules/acm/aws"
-  version = "2.12.0"
+  version = "3.2.0"
 
   create_certificate = var.acm_certificate_arn == "" ? true : false
 

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ data "aws_availability_zones" "available" {
 locals {
   azs             = var.azs != [] ? var.azs : data.aws_availability_zones.available.names
   vpc_id          = var.vpc_id == "" ? module.vpc[0].vpc_id : var.vpc_id
-  certificate_arn = var.acm_certificate_arn == "" ? module.certificate.this_acm_certificate_arn : var.acm_certificate_arn
+  certificate_arn = var.acm_certificate_arn == "" ? module.certificate.acm_certificate_arn : var.acm_certificate_arn
 
   refinery_url = "https://${coalesce(
     element(concat(aws_route53_record.refinery.*.fqdn, [""]), 0),

--- a/refinery.tf
+++ b/refinery.tf
@@ -1,6 +1,6 @@
 module "refinery" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.58.0"
+  version = "0.58.1"
 
   container_name         = "refinery"
   container_image        = "${var.image_repository}:${var.image_tag}"

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,7 +1,7 @@
 #tfsec:ignore:AWS082
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.2.0"
+  version = "3.3.0"
 
   count = var.vpc_id == "" ? 1 : 0
 


### PR DESCRIPTION
## Description

A long-overdue cleanup of GitHub Actions 🙂 I basically copied and adapted the workflows from other private repos. Dependabot should now be able to create PRs, test them, get them merged by Mergify, and then a nice GitHub release should be created.

Terraform modules were also bumped to the latest versions for tests.

## Notes

I did not test how this works with forks.
